### PR TITLE
[SE-4161] show download transcript button if no access token present

### DIFF
--- a/wistiavideo/static/html/wistiavideo.html
+++ b/wistiavideo/static/html/wistiavideo.html
@@ -7,6 +7,6 @@
     </div>
   </div>
   <p class="wistia_responsive_transcripts">
-    <a href="#" style="display: none;" class="wistia_transcripts_download">{{ download_transcripts_text }}</a>
+    <a href="#" style="display: none;" class="wistia_transcripts_download" data-api-enabled="{{ has_access_token }}">{{ download_transcripts_text }}</a>
   </p>
 </div>

--- a/wistiavideo/static/js/wistiavideo.js
+++ b/wistiavideo/static/js/wistiavideo.js
@@ -1,21 +1,44 @@
 function WistiaVideoXBlock(runtime, element) {
     "use strict";
 
-    const downloadHandlerUrl = runtime.handlerUrl(element, 'download_captions');
     const downloadBtnSelector = '.wistiavideo_block .wistia_responsive_transcripts .wistia_transcripts_download';
     const wistiaEmbeddedSelector = ".wistiavideo_block .wistia_responsive_padding .wistia_responsive_wrapper .wistia_embed";
+
     const mediaId = $(wistiaEmbeddedSelector).data("mediaId");
+    const apiEnabled = $(downloadBtnSelector).data("apiEnabled") === 'True';
+
+    const downloadHandlerUrl = runtime.handlerUrl(element, 'download_captions');
+    const captionUrlBase = `http://fast.wistia.net/embed/captions/${mediaId}.vtt`;
+
+    let embeddedVideo = undefined;
+    let currentCaptionLanguage = '';
 
     $(downloadBtnSelector, element).click(function (e) {
         e.preventDefault();
-        window.open(downloadHandlerUrl, '_blank');
+
+        const targetUrl = apiEnabled ? downloadHandlerUrl : `${captionUrlBase}?lang=${currentCaptionLanguage}`;
+
+        window.open(targetUrl, '_blank');
     });
 
     window._wq = window._wq || [];
 
-    _wq.push({ id: mediaId, onReady: function(video) {
-        video.plugin('captions').then(function (captions) { 
+    window._wq.push({ id: mediaId, onReady: function(video) {
+        embeddedVideo = video;
+
+        // Change caption language if user changes caption language
+        embeddedVideo.bind('captionschange', function (details) {
+            if (details.visible && currentCaptionLanguage != details.language) {
+                currentCaptionLanguage = details.language
+            }
+        });
+
+        embeddedVideo.plugin('captions').then(function (captions) { 
             if (captions.captions.length > 0) {
+                // Set the default caption language as the current
+                currentCaptionLanguage = captions.options.language;
+
+                // Show the download button
                 $(downloadBtnSelector).show();
             }
         });

--- a/wistiavideo/static/js/wistiavideo.js
+++ b/wistiavideo/static/js/wistiavideo.js
@@ -18,7 +18,7 @@ function WistiaVideoXBlock(runtime, element) {
 
         const targetUrl = apiEnabled ? downloadHandlerUrl : `${captionUrlBase}?lang=${currentCaptionLanguage}`;
 
-        window.open(targetUrl, '_blank');
+        window.open(targetUrl, '_blank', 'noopener');
     });
 
     window._wq = window._wq || [];

--- a/wistiavideo/tests/test_xblock.py
+++ b/wistiavideo/tests/test_xblock.py
@@ -46,6 +46,28 @@ class WistiaXblockTranscriptsDownloadTests(WistiaXblockBaseTests, unittest.TestC
     def test_download_button_exists(self):
         self.assertIn("wistia_transcripts_download", self.__render_html())
 
+    def test_access_token_not_set(self):
+        media_id = "12345abcde"
+        href = "https://example.wistia.com/medias/{}".format(media_id)
+
+        xblock = self.make_xblock(href=href)
+        rendered_html = xblock.student_view().body_html()
+
+        self.assertFalse(xblock.has_access_token)
+        self.assertIn("wistia_transcripts_download", rendered_html)
+        self.assertIn('data-api-enabled="False"', rendered_html)
+
+    def test_access_token_set(self):
+        media_id = "12345abcde"
+        href = "https://example.wistia.com/medias/{}".format(media_id)
+
+        xblock = self.make_xblock(href=href, access_token="token")
+        rendered_html = xblock.student_view().body_html()
+
+        self.assertTrue(xblock.has_access_token)
+        self.assertIn("wistia_transcripts_download", rendered_html)
+        self.assertIn('data-api-enabled="True"', rendered_html)
+
     @patch("wistiavideo.wistiavideo.requests")
     def test_send_request(self, mock_requests):
         media_id = "12345abcde"

--- a/wistiavideo/wistiavideo.py
+++ b/wistiavideo/wistiavideo.py
@@ -57,7 +57,7 @@ class CaptionDownloadMixin:
 
     @property
     def has_access_token(self):
-        return self.access_token != ''
+        return bool(self.access_token)
 
     @staticmethod
     def __compress_captions(srt_files):

--- a/wistiavideo/wistiavideo.py
+++ b/wistiavideo/wistiavideo.py
@@ -55,6 +55,10 @@ class CaptionDownloadMixin:
 
         return requests.get(url, params={"access_token": self.access_token}).json()
 
+    @property
+    def has_access_token(self):
+        return self.access_token != ''
+
     @staticmethod
     def __compress_captions(srt_files):
         """
@@ -171,6 +175,7 @@ class WistiaVideoXBlock(StudioEditableXBlockMixin, CaptionDownloadMixin, XBlock)
         context = {
             "download_transcripts_text": _("Download transcripts"),
             "media_id": self.media_id,
+            "has_access_token": self.has_access_token,
         }
 
         frag = Fragment(loader.render_template('static/html/wistiavideo.html', context))


### PR DESCRIPTION
This PR extends the download transcripts feature to download the default or selected transcripts for a Wistia video if no API token set for the video in Studio. In case no transcripts are available, the download button won't be shown.

This way it can be ensured that if the API token is set, the users can download all transcripts as one ZIP file, but if no API token set, the default/active transcript can be downloaded anyway.

**Dependencies**: None

**Sandbox URL of the video**: [video](https://preview.gabor-sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/2?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40b0d0695f5ce14eedb65ae20019edcd29)

**Screenshots**: 

![Screenshot 2021-03-07 at 20 18 44](https://user-images.githubusercontent.com/19173947/110299443-f475ad80-7ff5-11eb-9496-ed85894f5e8e.png)

**Sandbox URL**: N/A

**Testing instructions**:

1. Start Studio and LMS
2. Get an access token (https://<YOUR_ACCOUNT>.wistia.com/account/api)
3. Upload a video with transcript (attached to make it easier, but you can use any video and transcript)
4. Setup the XBlock as described in the README
5. Set the API token in the component settings
6. View the video in LMS
7. Validate that the transcripts can be downloaded as a ZIP file
8. Remove the API token
9. View the video in LMS
10. Validate the download button is still visible
11. Download the default/active transcript by clicking the download button
12. Validate that based on the browser type the transcript is opened in a new tab or downloaded
13. Remove all transcripts from the video on Wistia
14. Reload the video and validate no download button is shown

**Author notes and concerns**:

N/A

**Resources**

* [eng_gn_wwge9.srt.txt](https://github.com/appsembler/xblock-wistia/files/6100187/eng_gn_wwge9.srt.txt) - Remove the `.txt` suffix
* https://user-images.githubusercontent.com/19173947/110300133-d197c900-7ff6-11eb-9c35-217aa010b974.mp4

**Reviewers**
- [ ] @pkulkark
- [ ] @OmarIthawi (Sorry for pinging you, but you were the last one merging a PR 😇 )